### PR TITLE
Updating the Android build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ android/.idea/modules.xml
 android/.idea/workspace.xml
 android/.idea/navEditor.xml
 android/.idea/assetWizardSettings.xml
+android/app/src/main/assets/
 .DS_Store
 android/build
 android/captures

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,13 +3,13 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
-    buildToolsVersion "30.0.3"
+    namespace 'com.plushnode.nullspace'
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId "com.plushnode.nullspace"
-        minSdkVersion 18
-        targetSdkVersion 30
+        minSdkVersion 19
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 
@@ -17,7 +17,13 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags '-std=c++14'
+                // Add 16KB page size compatibility for Android 15+ devices
+                arguments '-DANDROID_ARM_NEON=TRUE'
             }
+        }
+        ndk {
+            // Ensure 16KB page size compatibility
+            abiFilters 'arm64-v8a', 'armeabi-v7a'
         }
         signingConfig signingConfigs.debug
     }
@@ -29,8 +35,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     externalNativeBuild {
         cmake {
@@ -42,10 +48,10 @@ android {
 
 dependencies {
 
-    implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.10.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
             android:name="com.plushnode.nullspace.MainActivity"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
             android:configChanges="orientation|keyboardHidden|screenSize"
-            android:screenOrientation="landscape">
+            android:screenOrientation="landscape"
+            android:exported="true">
 
             <meta-data android:name="android.app.lib_name" android:value="nullspace-android" />
 

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -2,38 +2,54 @@ cmake_minimum_required(VERSION 3.10.2)
 
 project("nullspace")
 
+# Define a variable for the project root to make paths cleaner
+set(PROJECT_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../../../..)
+
 set(CMAKE_CXX_STANDARD 14)
-add_definitions(-DIMGUI_IMPL_OPENGL_LOADER_GLAD -DIMGUI_IMPL_OPENGL_ES3)
 
 set(IMGUI_SOURCES
-        ../../../../../lib/imgui/imgui.cpp
-        ../../../../../lib/imgui/imgui_demo.cpp
-        ../../../../../lib/imgui/imgui_draw.cpp
-        ../../../../../lib/imgui/imgui_tables.cpp
-        ../../../../../lib/imgui/imgui_widgets.cpp
-        ../../../../../lib/imgui/backends/imgui_impl_android.cpp
-        ../../../../../lib/imgui/backends/imgui_impl_opengl3.cpp
+        ${PROJECT_ROOT}/lib/imgui/imgui.cpp
+        ${PROJECT_ROOT}/lib/imgui/imgui_demo.cpp
+        ${PROJECT_ROOT}/lib/imgui/imgui_draw.cpp
+        ${PROJECT_ROOT}/lib/imgui/imgui_tables.cpp
+        ${PROJECT_ROOT}/lib/imgui/imgui_widgets.cpp
+        ${PROJECT_ROOT}/lib/imgui/backends/imgui_impl_android.cpp
+        ${PROJECT_ROOT}/lib/imgui/backends/imgui_impl_opengl3.cpp
         ${ANDROID_NDK}/sources/android/native_app_glue/android_native_app_glue.c)
 
 set(CMAKE_SHARED_LINKER_FLAGS
     "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate"
 )
 
-file(GLOB_RECURSE SOURCES ../../../../../src/*.cpp)
-list(FILTER SOURCES EXCLUDE REGEX src/main.cpp$)
+# Add 16KB page size compatibility flags for Android 15+ devices
+if(ANDROID_ABI STREQUAL "arm64-v8a")
+    set(CMAKE_SHARED_LINKER_FLAGS
+        "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384"
+    )
+endif()
+
+# Note: file(GLOB_RECURSE) is convenient but might not update the build
+# system automatically if you add/remove .cpp files without touching CMakeLists.txt.
+file(GLOB_RECURSE SOURCES ${PROJECT_ROOT}/src/*.cpp)
+list(FILTER SOURCES EXCLUDE REGEX "null/main\\.cpp$") # Exclude the desktop main.cpp that uses GLFW
 
 add_library(nullspace-android
             SHARED
             ${IMGUI_SOURCES}
-            ../../../../../lib/glad/src/glad.cpp
+            ${PROJECT_ROOT}/lib/glad/src/glad.cpp
             ${SOURCES}
-            nullspace_android.cpp)
+            nullspace_android.cpp) # Assuming this is in the same dir as CMakeLists.txt
+
+# Use target_compile_definitions for better practice
+target_compile_definitions(nullspace-android PRIVATE
+    IMGUI_IMPL_OPENGL_LOADER_GLAD
+    IMGUI_IMPL_OPENGL_ES3)
 
 target_include_directories(nullspace-android PRIVATE
-        ../../../../../lib
-        ../../../../../
-        ../../../../../lib/imgui
-        ../../../../../lib/glad/include
+        ${PROJECT_ROOT}/lib
+        ${PROJECT_ROOT}/src  # Corrected path to find <null/HashMap.h> if it's in <PROJECT_ROOT>/src/null/
+        ${PROJECT_ROOT}/lib/imgui
+        ${PROJECT_ROOT}/lib/glad/include
         ${ANDROID_NDK}/sources/android/native_app_glue)
 
 target_link_libraries(nullspace-android

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.0"
+        classpath "com.android.tools.build:gradle:8.3.2"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed May 12 11:31:16 EDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The current Android build does not work with the latest Android Studio nor newer devices. This change makes it build again with the newer targeting and successfully runs on a Samsung S24+ device. In addition, I added a quick long-tap to bring the ESC menu and a quadrant detection to deploy a ship (temporarily).